### PR TITLE
Support specific devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Spawns logkitten with given options:
 
 * `platform: 'android' | 'ios'` - Platform to get the logs from: uses `adb logcat` for Android and `xcrun simctl` + `log` for iOS simulator.
 * `adbPath?: string` - Custom path to adb tool or `undefined` (used only when `platform` is `android`).
+* `deviceId?: string` - Specific device to target. For Android, this is the device serial number used with `adb -s`. For iOS, this is the simulator UDID used with `xcrun simctl`. If not provided, defaults to the current device (Android) or `booted` simulator (iOS).
 * `priority?: number` - Minimum priority of entries to show of `undefined`, which will include all entries with priority **DEBUG** (Android)/**DEFAULT** (iOS) or above.
 * `filter?: (entry: Entry) => boolean` - Optional filter function that receives each log entry and returns true to include it or false to exclude it.
 
@@ -217,6 +218,30 @@ const emitter = logkitten({
   platform: 'android',
   adbPath: '/custom/path/to/adb',
   priority: AndroidPriority.DEBUG,
+});
+```
+
+### Specific Device Selection
+
+**Android with specific device:**
+```ts
+import { logkitten, AndroidPriority } from 'logkitten';
+
+const emitter = logkitten({
+  platform: 'android',
+  deviceId: 'emulator-5554', // or device serial like 'R58M123456X'
+  priority: AndroidPriority.DEBUG,
+});
+```
+
+**iOS with specific simulator:**
+```ts
+import { logkitten, IosPriority } from 'logkitten';
+
+const emitter = logkitten({
+  platform: 'ios',
+  deviceId: 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890', // simulator UDID
+  priority: IosPriority.DEBUG,
 });
 ```
 

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -145,6 +145,25 @@ describe('Node API', () => {
           done();
         });
       });
+
+      it('should pass deviceId to Android logging process', () => {
+        const loggingEmitter = new EventEmitter();
+        (runAndroidLoggingProcess as jest.Mock).mockImplementationOnce(() => ({
+          stdout: loggingEmitter,
+          stderr: new EventEmitter(),
+        }));
+
+        logkitten({
+          platform: 'android',
+          deviceId: 'emulator-5554',
+          priority: AndroidPriority.DEBUG,
+        });
+
+        expect(runAndroidLoggingProcess).toHaveBeenCalledWith(
+          undefined,
+          'emulator-5554'
+        );
+      });
     });
   });
 
@@ -237,6 +256,25 @@ describe('Node API', () => {
           expect(entriesEmitted).toBe(1);
           done();
         }, 0);
+      });
+
+      it('should pass deviceId to iOS logging process', () => {
+        const loggingEmitter = new EventEmitter();
+        (runSimulatorLoggingProcess as jest.Mock).mockImplementationOnce(
+          () => ({
+            stdout: loggingEmitter,
+            stderr: new EventEmitter(),
+          })
+        );
+
+        logkitten({
+          platform: 'ios',
+          deviceId: 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890',
+        });
+
+        expect(runSimulatorLoggingProcess).toHaveBeenCalledWith(
+          'A1B2C3D4-E5F6-7890-ABCD-EF1234567890'
+        );
       });
     });
   });

--- a/src/android/adb.ts
+++ b/src/android/adb.ts
@@ -6,9 +6,12 @@ import {
   ERR_ANDROID_CANNOT_START_LOGCAT,
 } from '../errors';
 
-export function runAndroidLoggingProcess(adbPath?: string): ChildProcess {
+export function runAndroidLoggingProcess(
+  adbPath?: string,
+  deviceId?: string
+): ChildProcess {
   const execPath = getAdbPath(adbPath);
-  return spawnLogcatProcess(execPath);
+  return spawnLogcatProcess(execPath, deviceId);
 }
 
 export function getSdkRoot(): string | undefined {
@@ -23,9 +26,14 @@ export function getAdbPath(customPath?: string): string {
   return sdkRoot ? `${sdkRoot}/platform-tools/adb` : 'adb';
 }
 
-export function spawnLogcatProcess(adbPath: string): ChildProcess {
+export function spawnLogcatProcess(
+  adbPath: string,
+  deviceId?: string
+): ChildProcess {
+  const baseArgs = deviceId ? ['-s', deviceId] : [];
+
   try {
-    execFileSync(adbPath, ['logcat', '-c']);
+    execFileSync(adbPath, [...baseArgs, 'logcat', '-c']);
   } catch (error) {
     throw new CodeError(
       ERR_ANDROID_CANNOT_CLEAN_LOGCAT_BUFFER,
@@ -34,9 +42,13 @@ export function spawnLogcatProcess(adbPath: string): ChildProcess {
   }
 
   try {
-    return spawn(adbPath, ['logcat', '-v', 'time', 'process', 'tag'], {
-      stdio: 'pipe',
-    });
+    return spawn(
+      adbPath,
+      [...baseArgs, 'logcat', '-v', 'time', 'process', 'tag'],
+      {
+        stdio: 'pipe',
+      }
+    );
   } catch (error) {
     throw new CodeError(
       ERR_ANDROID_CANNOT_START_LOGCAT,

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,12 +21,13 @@ export { Entry } from './types';
 export type LogkittyOptions = {
   platform: Platform;
   adbPath?: string;
+  deviceId?: string;
   priority?: number;
   filter?: (entry: Entry) => boolean;
 };
 
 export function logkitten(options: LogkittyOptions): EventEmitter {
-  const { platform, adbPath, priority, filter: userFilter } = options;
+  const { platform, adbPath, deviceId, priority, filter: userFilter } = options;
   const emitter = new EventEmitter();
 
   if (
@@ -45,8 +46,8 @@ export function logkitten(options: LogkittyOptions): EventEmitter {
 
   const loggingProcess =
     platform === 'android'
-      ? runAndroidLoggingProcess(adbPath)
-      : runSimulatorLoggingProcess();
+      ? runAndroidLoggingProcess(adbPath, deviceId)
+      : runSimulatorLoggingProcess(deviceId);
 
   process.on('exit', () => {
     loggingProcess.kill();

--- a/src/ios/simulator.ts
+++ b/src/ios/simulator.ts
@@ -1,14 +1,16 @@
 import { ChildProcess, spawn } from 'child_process';
 import { CodeError, ERR_IOS_CANNOT_START_SYSLOG } from '../errors';
 
-export function runSimulatorLoggingProcess(): ChildProcess {
+export function runSimulatorLoggingProcess(deviceId?: string): ChildProcess {
+  const targetDevice = deviceId || 'booted';
+
   try {
     return spawn(
       'xcrun',
       [
         'simctl',
         'spawn',
-        'booted',
+        targetDevice,
         'log',
         'stream',
         '--type',


### PR DESCRIPTION
This PR adds support for targeting specific devices instead of only supporting 'booted' devices.

## Changes

- Add `deviceId` option to `LogkittyOptions` interface
- Support Android device selection using `adb -s <deviceId>`
- Support iOS simulator selection using `xcrun simctl spawn <deviceId>`
- Default to current device (Android) or 'booted' simulator (iOS) when deviceId not provided
- Add comprehensive documentation and usage examples
- Add tests for device selection functionality

## Usage

**Android with specific device:**
```ts
const emitter = logkitten({
  platform: 'android',
  deviceId: 'emulator-5554', // or device serial like 'R58M123456X'
  priority: AndroidPriority.DEBUG,
});
```

**iOS with specific simulator:**
```ts
const emitter = logkitten({
  platform: 'ios',
  deviceId: 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890', // simulator UDID
  priority: IosPriority.DEBUG,
});
```

Fixes #3