### PR TITLE
fix: add robust sigkill

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -47,5 +47,25 @@ describe('LogkittenEmitter (real process)', () => {
       await emitter.close();
       expect(onClose).toHaveBeenCalledTimes(1);
     });
+
+    it('should use SIGKILL timeout for stubborn processes', async () => {
+      // Create a process that ignores SIGTERM but can be killed with SIGKILL
+      const demo = spawn(process.execPath, [
+        '-e',
+        `process.on('SIGTERM', () => {}); setTimeout(() => {}, 5000);`,
+      ]);
+
+      const emitter = new LogkittenEmitter(demo);
+      const startTime = Date.now();
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      // Close should complete within 3 seconds (2s timeout + buffer)
+      await emitter.close();
+      const duration = Date.now() - startTime;
+
+      // Should take around 2 seconds due to SIGKILL timeout
+      expect(duration).toBeGreaterThan(1900); // At least 1.9 seconds
+      expect(duration).toBeLessThan(3000); // But less than 3 seconds
+    });
   });
 });


### PR DESCRIPTION
It looks like sometimes `xcrun` would not react to SIGTERM... 🤷‍♂️ 